### PR TITLE
extract sender from onix21 header

### DIFF
--- a/lib/onix/onix21.rb
+++ b/lib/onix/onix21.rb
@@ -88,6 +88,10 @@ module ONIX
 
     # ONIX 2.1 subset
 
+    class Header < SubsetDSL
+      element "FromCompany", :text
+    end
+
     class Title < SubsetDSL
       element "TitleType", :subset
       element "TitleText", :text

--- a/lib/onix/onix21.rb
+++ b/lib/onix/onix21.rb
@@ -90,10 +90,6 @@ module ONIX
 
     class Header < SubsetDSL
       element "FromCompany", :text
-      element "FromSAN", :text
-      element "FromEANNumber", :text
-      element "FromPerson", :text
-      element "FromEmail", :text
     end
 
     class Title < SubsetDSL

--- a/lib/onix/onix21.rb
+++ b/lib/onix/onix21.rb
@@ -90,6 +90,10 @@ module ONIX
 
     class Header < SubsetDSL
       element "FromCompany", :text
+      element "FromSAN", :text
+      element "FromEANNumber", :text
+      element "FromPerson", :text
+      element "FromEmail", :text
     end
 
     class Title < SubsetDSL

--- a/lib/onix/onix_message.rb
+++ b/lib/onix/onix_message.rb
@@ -161,7 +161,6 @@ module ONIX
                     end
                   end
                 else
-                  @raw_header_xml = e
                   @sender = ONIX21::Header.parse(e).from_company
                 end
               when tag_match("Product")

--- a/lib/onix/onix_message.rb
+++ b/lib/onix/onix_message.rb
@@ -52,7 +52,7 @@ module ONIX
     attr_accessor :sender, :adressee, :sent_date_time,
                   :default_language_of_text, :default_currency_code,
                   :products, :release
-    attr_reader :raw_header_xml
+    attr_reader :raw_header_xml, :header
 
     def initialize
       @products=[]
@@ -161,7 +161,7 @@ module ONIX
                     end
                   end
                 else
-                  @sender = ONIX21::Header.parse(e).from_company
+                  @header = ONIX21::Header.parse(e)
                 end
               when tag_match("Product")
                 product=nil

--- a/lib/onix/onix_message.rb
+++ b/lib/onix/onix_message.rb
@@ -142,9 +142,9 @@ module ONIX
             case e
               when tag_match("Header")
                 @raw_header_xml = e
-
-                e.elements.each do |t|
-                  case t
+                if @release =~ /^3.0/
+                  e.elements.each do |t|
+                    case t
                     when tag_match("Sender")
                       @sender=Sender.parse(t)
                     when tag_match("Addressee")
@@ -158,7 +158,11 @@ module ONIX
                       @default_currency_code=t.text
                     else
                       unsupported(t)
+                    end
                   end
+                else
+                  @raw_header_xml = e
+                  @sender = ONIX21::Header.parse(e).from_company
                 end
               when tag_match("Product")
                 product=nil

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -858,6 +858,10 @@ class TestImOnix < Minitest::Test
       @product=@message.products.last
     end
 
+    should "return the sender" do
+      assert_equal "Jouve", @message.sender
+    end
+
     should "return the file's header as raw xml" do
       raw_header_xml = "<Header>\n    <FromCompany>Jouve</FromCompany>\n    <ToCompany>BnF</ToCompany>\n    <SentDate>20160114</SentDate>\n  </Header>"
 

--- a/test/test_im_onix.rb
+++ b/test/test_im_onix.rb
@@ -858,8 +858,8 @@ class TestImOnix < Minitest::Test
       @product=@message.products.last
     end
 
-    should "return the sender" do
-      assert_equal "Jouve", @message.sender
+    should "return the from_company in header" do
+      assert_equal "Jouve", @message.header.from_company
     end
 
     should "return the file's header as raw xml" do


### PR DESCRIPTION
This hacks in the ability to extract the sender_name out of an Onix21 file.

This is introducing a header attribute because Onix21's header doesn't have much more sub-composites like Onix30. 

