### PR TITLE
feature/add-missing-publishing-status-code

### DIFF
--- a/data/codelists/codelist-64.yml
+++ b/data/codelists/codelist-64.yml
@@ -13,6 +13,7 @@
   '10': Remaindered
   '11': WithdrawnFromSale
   '12': Recalled
+  '13': ActiveButNotSoldSeparately
   '15': Recalled
   '16': TemporarilyWithdrawnFromSale
   '17': PermanentlyWithdrawnFromSale

--- a/data/onix21/codelists/codelist-64.yml
+++ b/data/onix21/codelists/codelist-64.yml
@@ -13,6 +13,7 @@
   '10': Remaindered
   '11': WithdrawnFromSale
   '12': Recalled
+  '13': ActiveButNotSoldSeparately
   '15': Recalled
   '16': TemporarilyWithdrawnFromSale
   '17': PermanentlyWithdrawnFromSale


### PR DESCRIPTION
Adds the missing publishing status code `ActiveButNotSoldSeparately` to codelist 64 for both Onix 3.0 and 2.1.