### PR TITLE
chore(dependencies): update Rdoc to address security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source "https://rubygems.org"
 
-gem 'nokogiri'
+gem "nokogiri"
 
 group :development do
   gem "shoulda", ">= 0"
-  gem "rdoc", "~> 3.12"
+  gem "rdoc", "~> 6.7"
   gem "bundler"
-  gem "jeweler", "~> 1.8.4"
+  gem "jeweler", "~> 2.3"
   gem "simplecov", ">= 0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,123 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    addressable (2.4.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    builder (3.3.0)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    docile (1.4.0)
+    drb (2.2.1)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    git (1.11.0)
+      rchardet (~> 1.8)
+    github_api (0.16.0)
+      addressable (~> 2.4.0)
+      descendants_tracker (~> 0.0.4)
+      faraday (~> 0.8, < 0.10)
+      hashie (>= 3.4)
+      mime-types (>= 1.16, < 3.0)
+      oauth2 (~> 1.0)
+    hashie (5.0.0)
+    highline (3.1.0)
+      reline
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    io-console (0.7.2)
+    jeweler (2.3.9)
+      builder
+      bundler
+      git (>= 1.2.5)
+      github_api (~> 0.16.0)
+      highline (>= 1.6.15)
+      nokogiri (>= 1.5.10)
+      psych
+      rake
+      rdoc
+      semver2
+    jwt (2.8.2)
+      base64
+    mime-types (2.99.3)
+    minitest (5.24.1)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.4.1)
+    mutex_m (0.2.0)
+    nokogiri (1.16.6-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.6-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-linux)
+      racc (~> 1.4)
+    oauth2 (1.4.8)
+      faraday (>= 0.8, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    psych (5.1.2)
+      stringio
+    racc (1.8.0)
+    rack (2.2.9)
+    rake (13.2.1)
+    rchardet (1.8.0)
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
+    reline (0.5.9)
+      io-console (~> 0.5)
+    semver2 (3.4.2)
+    shoulda (4.0.0)
+      shoulda-context (~> 2.0)
+      shoulda-matchers (~> 4.0)
+    shoulda-context (2.0.0)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    stringio (3.1.1)
+    thread_safe (0.3.6)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  bundler
+  jeweler (~> 2.3)
+  nokogiri
+  rdoc (~> 6.7)
+  shoulda
+  simplecov
+
+BUNDLED WITH
+   2.5.16


### PR DESCRIPTION
In RDoc 3.11 through 6.x before 6.3.1, as distributed with Ruby through 3.0.1, it is possible to execute arbitrary code via | and tags in a filename.

Fixes following vulnerabilities:

* https://github.com/blinkist/im_onix/security/dependabot/4
* https://github.com/blinkist/im_onix/security/dependabot/3